### PR TITLE
Hop oils (#105)

### DIFF
--- a/docs/hop.json.md
+++ b/docs/hop.json.md
@@ -1,6 +1,6 @@
 The schema defines the following types:
 
-## HopVarietyBase 
+## HopVarietyBase
 
 HopVarietyBase provides unique properties to identify individual records of a hop variety
 
@@ -8,15 +8,15 @@ HopVarietyBase provides unique properties to identify individual records of a ho
 
 ### Properties
 
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-| **name** | string|  | :white_check_mark: |
-| **origin** | string|  |  |
-| **form** |  'extract'  , 'leaf'  , 'leaf (wet)'  , 'pellet'  , 'powder'  , 'plug' |  |  |
-| **alpha_acid_units** | number|  | :white_check_mark: |
-| **beta_acid_units** | number|  |  |
+|                      | Type                                                             | Description | Required           |
+| -------------------- | ---------------------------------------------------------------- | ----------- | ------------------ |
+| **name**             | string                                                           |             | :white_check_mark: |
+| **origin**           | string                                                           |             |                    |
+| **form**             | 'extract' , 'leaf' , 'leaf (wet)' , 'pellet' , 'powder' , 'plug' |             |                    |
+| **alpha_acid_units** | number                                                           |             | :white_check_mark: |
+| **beta_acid_units**  | number                                                           |             |                    |
 
-## VarietyInformation 
+## VarietyInformation
 
 VarietyInformation collects the attributes of a hop variety to store as record information
 
@@ -26,20 +26,16 @@ Parent: [HopVarietyBase](#hopvarietybase)
 
 ### Properties
 
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-| **type** |  'aroma'  , 'bittering'  , 'flavor'  , 'aroma/bittering'  , 'bittering/flavor'  , 'aroma/flavor'  , 'aroma/bittering/flavor' |  |  |
-| **notes** | string|  |  |
-| **percent_lost** | [PercentType](measureable_units.json.md#percenttype)|  |  |
-| **substitutes** | string|  |  |
-| **humulene** | number|  |  |
-| **caryophyllene** | number|  |  |
-| **cohumulone** | number|  |  |
-| **myrcene** | number|  |  |
-| **farnesene** | number|  |  |
-| **inventory** | object|  |  |
+|                  | Type                                                                                                                  | Description | Required |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------- | ----------- | -------- |
+| **type**         | 'aroma' , 'bittering' , 'flavor' , 'aroma/bittering' , 'bittering/flavor' , 'aroma/flavor' , 'aroma/bittering/flavor' |             |          |
+| **notes**        | string                                                                                                                |             |          |
+| **percent_lost** | [PercentType](measureable_units.json.md#percenttype)                                                                  |             |          |
+| **substitutes**  | string                                                                                                                |             |          |
+| **oil_content**  | object                                                                                                                |             |          |
+| **inventory**    | object                                                                                                                |             |          |
 
-## HopAdditionType 
+## HopAdditionType
 
 HopAdditionType collects the attributes of each hop ingredient for use in a recipe hop bil
 
@@ -47,23 +43,20 @@ HopAdditionType collects the attributes of each hop ingredient for use in a reci
 
 Parent: [HopVarietyBase](#hopvarietybase)
 
+## IBUEstimateType
 
-## IBUEstimateType 
-
-*no description yet*
+_no description yet_
 
 `IBUEstimateType` type: `undefined`
 
 ### Properties
 
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-| **method** | [IBUMethodType](#ibumethodtype)|  |  |
+|            | Type                            | Description | Required |
+| ---------- | ------------------------------- | ----------- | -------- |
+| **method** | [IBUMethodType](#ibumethodtype) |             |          |
 
-## IBUMethodType 
+## IBUMethodType
 
-*no description yet*
+_no description yet_
 
 `IBUMethodType` type: `string`
-
-

--- a/json/hop.json
+++ b/json/hop.json
@@ -57,21 +57,54 @@
             "substitutes": {
               "type": "string"
             },
-            "humulene": {
-              "type": "number"
+            "oil_content": {
+              "type": "object",
+              "properties": {
+                "total_oil_ml_per_100g": {
+                  "type": "number"
+                },
+                "humulene": {
+                  "$ref": "measureable_units.json#/definitions/PercentType"
+                },
+                "caryophyllene": {
+                  "$ref": "measureable_units.json#/definitions/PercentType"
+                },
+                "cohumulone": {
+                  "$ref": "measureable_units.json#/definitions/PercentType"
+                },
+                "myrcene": {
+                  "$ref": "measureable_units.json#/definitions/PercentType"
+                },
+                "farnesene": {
+                  "$ref": "measureable_units.json#/definitions/PercentType"
+                },
+                "geraniol": {
+                  "$ref": "measureable_units.json#/definitions/PercentType"
+                },
+                "b-pinene": {
+                  "$ref": "measureable_units.json#/definitions/PercentType"
+                },
+                "linalool": {
+                  "$ref": "measureable_units.json#/definitions/PercentType"
+                },
+                "limonene": {
+                  "$ref": "measureable_units.json#/definitions/PercentType"
+                },
+                "nerol": {
+                  "$ref": "measureable_units.json#/definitions/PercentType"
+                },
+                "pinene": {
+                  "$ref": "measureable_units.json#/definitions/PercentType"
+                },
+                "polyphenols": {
+                  "$ref": "measureable_units.json#/definitions/PercentType"
+                },
+                "xanthohumol": {
+                  "$ref": "measureable_units.json#/definitions/PercentType"
+                }
+              }
             },
-            "caryophyllene": {
-              "type": "number"
-            },
-            "cohumulone": {
-              "type": "number"
-            },
-            "myrcene": {
-              "type": "number"
-            },
-            "farnesene": {
-              "type": "number"
-            },
+
             "inventory": {
               "type": "object",
               "additionalProperties": false,
@@ -157,7 +190,6 @@
               }
             }
           },
-
           "amount": {
             "oneOf": [
               {
@@ -167,9 +199,6 @@
                 "$ref": "measureable_units.json#/definitions/MassType"
               }
             ]
-          },
-          "temperature": {
-            "$ref": "measureable_units.json#/definitions/TemperatureType"
           }
         },
         {


### PR DESCRIPTION
Closes #82 under a new oil_content object, added separately so that it can avoid the no additional properties restriction.